### PR TITLE
Fixed repeated style names issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Original project by CodeZombie
-I tweaked the values to fix an issue regarding repeated style names and was successfulin doing so
-Unfortunately style names like 'expanded', 'semi-expanded', 'condensed', etc. are ignored
-Iam looking for a solution and will keep updating this repository
+### Original project by [CodeZombie](https://github.com/CodeZombie/TypeRip)
+* I tweaked the values to fix an issue regarding repeated style names and was successfulin doing so
+* Unfortunately style names like 'expanded', 'semi-expanded', 'condensed', etc. are ignored
+* Iam looking for a solution and will keep updating this repository

--- a/README.md
+++ b/README.md
@@ -1,41 +1,4 @@
-# TypeRip
-The Adobe Font ripper.
-## [Get It Here](http://codezombie.github.io/TypeRip/)
-
-### How to use it
-  1. Enter an Adobe Fonts [font family](https://fonts.adobe.com/fonts) or [font collection](https://fonts.adobe.com/collections) URL into the address bar, then press enter.
-  2. Browse the available fonts under this family, using the download button to save them to your machine.
-  3. That's it.
-
-### Terms
-* Do not use any downloaded fonts for anything other than testing purposes. Think of it like a try-before-you-buy system. This tool merely saves a copy of what Adobe makes publicly available through their website, but this does not give you the legal right to use the fonts as if you have purchased a license. If you want to publish any work using these fonts, you _must_ purchase a license through adobe.
-
-### Whats new?
-
-May 5, 2021:
-* Typerip can now rip the entire available character set from any font. Big thanks to everyone that reported bugs and collected information on this issue.
-* Added the option to download fonts without processing. This is useful if your download hangs and/or crashes your browser. Downloading the fonts without processing will always work, but you will have to edit the fonts manually to change their names and ensure compatibility with your OS.
-
-May 3, 2021:
-* Added the ability to read font collection URLs and download their contents as you would with a font family.
-* Added a "Download All" button to font families and collections, downloading a single zip of all the contents of the font pack.
-* Fonts now download as a ZIP archive.
-* Switched to a more consistent CORS proxy.
-
-March 22, 2020:
-* Cosmetic fixes
-* Removed all references to "TypeKit", as Adobe has renamed the service to "Adobe Fonts"
-
-March 9, 2020:
-* Fixed a bug in OpenType.js that would fail to re-encode some fonts.
-
-Oct 21, 2019:
-* Rewrote entire application from scratch
-* New, cleaner and simpler user interface
-* Fonts are automatically repaired and renamed correctly
-
-### Screenshot
-![Screenshot #1](https://i.imgur.com/5cyZTJ4.png)
-
-### License
-typerip.js is released under the WTFPL (http://www.wtfpl.net/)
+Original project by CodeZombie
+I tweaked the values to fix an issue regarding repeated style names and was successfulin doing so
+Unfortunately style names like 'expanded', 'semi-expanded', 'condensed', etc. are ignored
+Iam looking for a solution and will keep updating this repository

--- a/js/opentype.js
+++ b/js/opentype.js
@@ -13033,23 +13033,26 @@
 
 	        // OS X will complain if the names are empty, so we put a single space everywhere by default.
 	        this.names = {
-	            fontFamily: {en: options.familyName || ' '},
-	            fontSubfamily: {en: options.styleName || ' '},
+	            fontFamily: {en: options.familyName + ' ' + options.styleName || ''},
+	            fontSubfamily: {en: options.styleName || ''},
 	            fullName: {en: options.fullName || options.familyName + ' ' + options.styleName},
 	            // postScriptName may not contain any whitespace
 	            postScriptName: {en: options.postScriptName || (options.familyName + options.styleName).replace(/\s/g, '')},
-	            designer: {en: options.designer || ' '},
-	            designerURL: {en: options.designerURL || ' '},
-	            manufacturer: {en: options.manufacturer || ' '},
-	            manufacturerURL: {en: options.manufacturerURL || ' '},
-	            license: {en: options.license || ' '},
-	            licenseURL: {en: options.licenseURL || ' '},
-	            version: {en: options.version || 'Version 0.1'},
-	            description: {en: options.description || ' '},
-	            copyright: {en: options.copyright || ' '},
-	            trademark: {en: options.trademark || ' '}
+	            designer: {en: options.designer || ''},
+	            designerURL: {en: options.designerURL || ''},
+	            manufacturer: {en: options.manufacturer || ''},
+	            manufacturerURL: {en: options.manufacturerURL || ''},
+	            license: {en: options.license || ''},
+	            licenseURL: {en: options.licenseURL || ''},
+	            version: {en: options.version || 'Version 1.0'},
+	            description: {en: options.description || 'This typeface is downloaded using TypeRip (c) 2022. The downloaded file should be viewed as a preview and not as a full proof product.'},
+	            copyright: {en: options.copyright || 'TypeRip 2022 (c)'},
+	            trademark: {en: options.trademark || ''},
+	            preferredFamily: {en: options.familyName || ''},
+	            preferredSubfamily: {en: options.styleName || ''},
+	            uniqueID: {en: options.uniqueID || options.familyName +' '+ options.styleName}
 	        };
-	        this.unitsPerEm = options.unitsPerEm || 1000;
+	        this.unitsPerEm = options.unitsPerEm || 1024;
 	        this.ascender = options.ascender;
 	        this.descender = options.descender;
 	        this.createdTimestamp = options.createdTimestamp;

--- a/js/typerip.js
+++ b/js/typerip.js
@@ -239,13 +239,14 @@ var TypeRip = {
                     
                     //create a structure of font data with fields from the parsed font.
                     let newFontData = {
+                        fontName: font_.name,
                         familyName: font_.familyName,
                         styleName: font_.style,
                         glyphs: rebuiltGlyphs
                     }
 
                     //extract as much available data out of the existing font data and copy it over to the new font:
-                    let optionalFontDataFields = ['defaultWidthX', 'nominalWidthX', 'unitsPerEm', 'ascender', 'descender' ]
+                    let optionalFontDataFields = ['defaultWidthX', 'nominalWidthX', 'unitsPerEm', 'ascender', 'descender', 'copyright', 'designers' ]
                     optionalFontDataFields.forEach(field => {
                         if(fontData_[field] != null) {
                             newFontData[field] = fontData_[field]
@@ -260,4 +261,3 @@ var TypeRip = {
         }
     }
 }
-


### PR DESCRIPTION
Somehow managed to fix the repeated style names issue which was causing a problem whilst installing the ripped fonts. Now it is able to differentiate between weights such as 'regular' and 'regular italic' both which previously were recognized as 'regular' leading to the 'Font regular is already installed' error. However I was not able to set separate values for styles such as 'expanded', 'semi-expanded', 'condensed', etc. Iam working on it and will try to fix it soon.